### PR TITLE
Add LICENSE file and repository field to package.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 DBT Runner Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "VS Code extension for running dbt projects with Snowflake key pair authentication",
   "version": "0.1.0",
   "publisher": "jason-zondor",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jasonzondor/code_dbt_runner.git"
+  },
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
This pull request adds licensing information and repository metadata to the project, improving transparency and compliance.

Legal and project metadata:

* Added a new `LICENSE` file with the MIT License, specifying usage permissions and liability disclaimers.
* Updated `package.json` to include a `repository` field with the project's GitHub URL for better project discoverability and attribution.